### PR TITLE
Update name space to publish op packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dropday/module-orderautomation",
+    "name": "dropday-io/module-orderautomation",
     "description": "Intergration for Dropday. Order automation; dropshipping and supplier automation",
     "type": "magento2-module",
     "license": "MIT",


### PR DESCRIPTION
Packagist.org:

Warning: The vendor name "dropday" was already claimed by someone else on Packagist.org. You may ask them to add your package and give you maintainership access. If they add you as a maintainer on any package in that vendor namespace, you will then be able to add new packages in that namespace. The packages already in that vendor namespace can be found at dropday.If those packages belong to you but were submitted by someone else, you can contact us to resolve the issue.