### PR TITLE
Check if the order is paid

### DIFF
--- a/Observer/Sales/OrderPlaceAfter.php
+++ b/Observer/Sales/OrderPlaceAfter.php
@@ -49,6 +49,12 @@ class OrderPlaceAfter implements ObserverInterface
     {
         /** @var Order $order */
         $order = $observer->getEvent()->getOrder();
+        
+        // Check if the order is paid
+        if($order->getState() !== Order::STATE_PROCESSING) {
+            return;
+        }
+
         try {
             if (!$this->helper->isEnabled()) {
                 return;


### PR DESCRIPTION
Order that are Pending or Canceled are send to the Dropday API. This is not desired, since the order is not paid. Therefor, it should not be shipped.

This fix checks if the order is "Processing."